### PR TITLE
fix: removing redundant form label

### DIFF
--- a/src/app/operations/fieldForm.tsx
+++ b/src/app/operations/fieldForm.tsx
@@ -43,7 +43,6 @@ const FieldForm = ({ field, form, index }: Props) => {
             name={`field.${index}.label`}
             render={({ field }) => (
               <FormItem>
-                <FormLabel>Operation name</FormLabel>
                 <FormControl>
                   <Input placeholder="" {...field} />
                 </FormControl>


### PR DESCRIPTION
In the app the label "Operation name" is unnecessary and redudant.
This is to remove it.
![image](https://github.com/user-attachments/assets/e77cb14a-8b2e-4061-ad1d-b3b6db84e815)